### PR TITLE
Fix: Remove focus ring from Quit button

### DIFF
--- a/Sources/ClaudeUsageMenuBar/MenuBarContentView.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarContentView.swift
@@ -120,6 +120,7 @@ struct MenuBarContentView: View {
                 }
                 .font(.system(size: 11, weight: .medium))
                 .buttonStyle(.plain)
+                .focusable(false)
                 .foregroundColor(.secondary)
             }
         }


### PR DESCRIPTION
## Summary
Remove the blue focus ring from the Quit button to maintain consistent UI behavior.

## Problem
When opening the menu, the Quit button sometimes shows a blue focus ring, making it difficult to see what the button is.

## Solution
Add \ to the Quit button, consistent with the refresh button fix applied earlier.

## Test plan
- [x] Open the menu
- [x] Verify no blue focus ring appears on Quit button
- [x] Verify button is still clickable
- [x] Verify consistent behavior with refresh button

🤖 Generated with [Claude Code](https://claude.ai/code)