### PR TITLE
Menu display toggle

### DIFF
--- a/Sources/ClaudeUsageMenuBar/MenuBarContentView.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarContentView.swift
@@ -102,6 +102,12 @@ struct MenuBarContentView: View {
             
             // Settings section
             VStack(spacing: 8) {
+                Toggle("Menu Bar Tokens", isOn: Binding(
+                    get: { usageManager.showsTokenCountInMenuBar },
+                    set: { usageManager.setShowsTokenCountInMenuBar($0) }
+                ))
+                .font(.system(size: 12, weight: .medium))
+
                 // Currency setting
                 HStack {
                     Text("Currency")

--- a/Sources/ClaudeUsageMenuBar/MenuBarContentView.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarContentView.swift
@@ -31,7 +31,7 @@ struct MenuBarContentView: View {
                         Text("Input")
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(.secondary)
-                        Text(formatTokens(usageManager.todayInputTokens))
+                        Text(TokenFormatter.compact(usageManager.todayInputTokens))
                             .font(.system(size: 13, weight: .medium, design: .monospaced))
                             .foregroundColor(.primary)
                     }
@@ -40,7 +40,7 @@ struct MenuBarContentView: View {
                         Text("Output")
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(.secondary)
-                        Text(formatTokens(usageManager.todayOutputTokens))
+                        Text(TokenFormatter.compact(usageManager.todayOutputTokens))
                             .font(.system(size: 13, weight: .medium, design: .monospaced))
                             .foregroundColor(.primary)
                     }
@@ -74,7 +74,7 @@ struct MenuBarContentView: View {
                         Text("Input")
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(.secondary)
-                        Text(formatTokens(usageManager.monthInputTokens))
+                        Text(TokenFormatter.compact(usageManager.monthInputTokens))
                             .font(.system(size: 13, weight: .medium, design: .monospaced))
                             .foregroundColor(.primary)
                     }
@@ -83,7 +83,7 @@ struct MenuBarContentView: View {
                         Text("Output")
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(.secondary)
-                        Text(formatTokens(usageManager.monthOutputTokens))
+                        Text(TokenFormatter.compact(usageManager.monthOutputTokens))
                             .font(.system(size: 13, weight: .medium, design: .monospaced))
                             .foregroundColor(.primary)
                     }
@@ -210,17 +210,7 @@ struct MenuBarContentView: View {
         .frame(width: 280)
     }
     
-    private func formatTokens(_ count: Int) -> String {
-        if count >= 1_000_000 {
-            return String(format: "%.1fM", Double(count) / 1_000_000)
-        } else if count >= 1_000 {
-            return String(format: "%.1fK", Double(count) / 1_000)
-        } else {
-            return "\(count)"
-        }
-    }
-    
-    
+
     private func formatLastUpdated() -> String {
         guard let lastUpdate = usageManager.lastUpdated else {
             return "Never"

--- a/Sources/ClaudeUsageMenuBar/MenuBarContentView.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarContentView.swift
@@ -102,11 +102,26 @@ struct MenuBarContentView: View {
             
             // Settings section
             VStack(spacing: 8) {
-                Toggle("Menu Bar Tokens", isOn: Binding(
-                    get: { usageManager.showsTokenCountInMenuBar },
-                    set: { usageManager.setShowsTokenCountInMenuBar($0) }
-                ))
-                .font(.system(size: 12, weight: .medium))
+                HStack {
+                    Text("Menu Bar")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.secondary)
+
+                    Spacer()
+
+                    Picker("", selection: $usageManager.menuBarDisplayMode) {
+                        ForEach(MenuBarDisplayMode.allCases, id: \.self) { mode in
+                            Text(mode.displayName)
+                                .tag(mode)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 90)
+                    .font(.system(size: 11))
+                    .onChange(of: usageManager.menuBarDisplayMode) { newMode in
+                        usageManager.setMenuBarDisplayMode(newMode)
+                    }
+                }
 
                 // Currency setting
                 HStack {
@@ -122,7 +137,7 @@ struct MenuBarContentView: View {
                         }
                     }
                     .pickerStyle(.menu)
-                    .frame(width: 65)
+                    .frame(width: 78)
                     .font(.system(size: 11))
                     .onChange(of: currencyManager.selectedCurrency) { _ in
                         Task {

--- a/Sources/ClaudeUsageMenuBar/MenuBarDisplayMode.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarDisplayMode.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum MenuBarDisplayMode: String, CaseIterable {
+    case cost = "cost"
+    case tokens = "tokens"
+    case both = "both"
+
+    var displayName: String {
+        switch self {
+        case .cost:
+            return "Cost"
+        case .tokens:
+            return "Tokens"
+        case .both:
+            return "Both"
+        }
+    }
+}

--- a/Sources/ClaudeUsageMenuBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarLabelView.swift
@@ -5,20 +5,8 @@ struct MenuBarLabelView: View {
     @StateObject private var currencyManager = CurrencyManager.shared
     
     var body: some View {
-        if usageManager.showsTokenCountInMenuBar {
-            if usageManager.todayTotalTokens > 0 || !usageManager.isLoading {
-                Text("\(formatTokens(usageManager.todayTotalTokens)) tok")
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-            } else {
-                Text("...")
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundColor(.secondary)
-            }
-        } else if let todayCost = usageManager.todayCost {
-            Text(currencyManager.formatCurrency(todayCost))
+        if let labelText = menuBarLabelText() {
+            Text(labelText)
                 .font(.system(.caption, design: .monospaced))
                 .foregroundColor(.primary)
                 .lineLimit(1)
@@ -32,6 +20,26 @@ struct MenuBarLabelView: View {
             Text("--")
                 .font(.system(.caption, design: .monospaced))
                 .foregroundColor(.secondary)
+        }
+    }
+
+    private func menuBarLabelText() -> String? {
+        switch usageManager.menuBarDisplayMode {
+        case .cost:
+            guard let todayCost = usageManager.todayCost else {
+                return nil
+            }
+            return currencyManager.formatCurrency(todayCost)
+        case .tokens:
+            if usageManager.todayTotalTokens > 0 || !usageManager.isLoading {
+                return "\(formatTokens(usageManager.todayTotalTokens)) tok"
+            }
+            return nil
+        case .both:
+            guard let todayCost = usageManager.todayCost else {
+                return nil
+            }
+            return "\(currencyManager.formatCurrency(todayCost)) \(formatTokens(usageManager.todayTotalTokens)) tok"
         }
     }
 

--- a/Sources/ClaudeUsageMenuBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarLabelView.swift
@@ -32,24 +32,14 @@ struct MenuBarLabelView: View {
             return currencyManager.formatCurrency(todayCost)
         case .tokens:
             if usageManager.todayTotalTokens > 0 || !usageManager.isLoading {
-                return "\(formatTokens(usageManager.todayTotalTokens)) tok"
+                return "\(TokenFormatter.compact(usageManager.todayTotalTokens)) tok"
             }
             return nil
         case .both:
             guard let todayCost = usageManager.todayCost else {
                 return nil
             }
-            return "\(formatTokens(usageManager.todayTotalTokens)) tok (\(currencyManager.formatCurrency(todayCost)))"
-        }
-    }
-
-    private func formatTokens(_ count: Int) -> String {
-        if count >= 1_000_000 {
-            return String(format: "%.1fM", Double(count) / 1_000_000)
-        } else if count >= 1_000 {
-            return String(format: "%.1fK", Double(count) / 1_000)
-        } else {
-            return "\(count)"
+            return "\(TokenFormatter.compact(usageManager.todayTotalTokens)) tok (\(currencyManager.formatCurrency(todayCost)))"
         }
     }
 }

--- a/Sources/ClaudeUsageMenuBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarLabelView.swift
@@ -5,8 +5,19 @@ struct MenuBarLabelView: View {
     @StateObject private var currencyManager = CurrencyManager.shared
     
     var body: some View {
-        // Cost display - always show value if available, even while loading
-        if let todayCost = usageManager.todayCost {
+        if usageManager.showsTokenCountInMenuBar {
+            if usageManager.todayTotalTokens > 0 || !usageManager.isLoading {
+                Text("\(formatTokens(usageManager.todayTotalTokens)) tok")
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            } else {
+                Text("...")
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.secondary)
+            }
+        } else if let todayCost = usageManager.todayCost {
             Text(currencyManager.formatCurrency(todayCost))
                 .font(.system(.caption, design: .monospaced))
                 .foregroundColor(.primary)
@@ -21,6 +32,16 @@ struct MenuBarLabelView: View {
             Text("--")
                 .font(.system(.caption, design: .monospaced))
                 .foregroundColor(.secondary)
+        }
+    }
+
+    private func formatTokens(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        } else if count >= 1_000 {
+            return String(format: "%.1fK", Double(count) / 1_000)
+        } else {
+            return "\(count)"
         }
     }
 }

--- a/Sources/ClaudeUsageMenuBar/MenuBarLabelView.swift
+++ b/Sources/ClaudeUsageMenuBar/MenuBarLabelView.swift
@@ -39,7 +39,7 @@ struct MenuBarLabelView: View {
             guard let todayCost = usageManager.todayCost else {
                 return nil
             }
-            return "\(currencyManager.formatCurrency(todayCost)) \(formatTokens(usageManager.todayTotalTokens)) tok"
+            return "\(formatTokens(usageManager.todayTotalTokens)) tok (\(currencyManager.formatCurrency(todayCost)))"
         }
     }
 

--- a/Sources/ClaudeUsageMenuBar/TokenFormatter.swift
+++ b/Sources/ClaudeUsageMenuBar/TokenFormatter.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum TokenFormatter {
+    static func compact(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        } else if count >= 1_000 {
+            return String(format: "%.1fK", Double(count) / 1_000)
+        } else {
+            return "\(count)"
+        }
+    }
+}

--- a/Sources/ClaudeUsageMenuBar/UsageManager.swift
+++ b/Sources/ClaudeUsageMenuBar/UsageManager.swift
@@ -6,6 +6,7 @@ class UsageManager: ObservableObject {
     @Published var todayInputTokens: Int = 0
     @Published var todayOutputTokens: Int = 0
     @Published var todayCost: Double? = nil
+    @Published var showsTokenCountInMenuBar: Bool = false
     
     @Published var monthInputTokens: Int = 0
     @Published var monthOutputTokens: Int = 0
@@ -30,6 +31,7 @@ class UsageManager: ObservableObject {
            let mode = CostMode(rawValue: savedMode) {
             self.costMode = mode
         }
+        self.showsTokenCountInMenuBar = UserDefaults.standard.bool(forKey: "showsTokenCountInMenuBar")
         
         // Try to load cached values immediately for instant display
         loadCachedValues()
@@ -128,6 +130,15 @@ class UsageManager: ObservableObject {
         Task {
             await refreshUsage()
         }
+    }
+
+    func setShowsTokenCountInMenuBar(_ showsTokenCount: Bool) {
+        showsTokenCountInMenuBar = showsTokenCount
+        UserDefaults.standard.set(showsTokenCount, forKey: "showsTokenCountInMenuBar")
+    }
+
+    var todayTotalTokens: Int {
+        todayInputTokens + todayOutputTokens
     }
     
     private func loadUsageDataOptimized() async throws -> UsageStats {

--- a/Sources/ClaudeUsageMenuBar/UsageManager.swift
+++ b/Sources/ClaudeUsageMenuBar/UsageManager.swift
@@ -6,7 +6,7 @@ class UsageManager: ObservableObject {
     @Published var todayInputTokens: Int = 0
     @Published var todayOutputTokens: Int = 0
     @Published var todayCost: Double? = nil
-    @Published var showsTokenCountInMenuBar: Bool = false
+    @Published var menuBarDisplayMode: MenuBarDisplayMode = .cost
     
     @Published var monthInputTokens: Int = 0
     @Published var monthOutputTokens: Int = 0
@@ -31,7 +31,13 @@ class UsageManager: ObservableObject {
            let mode = CostMode(rawValue: savedMode) {
             self.costMode = mode
         }
-        self.showsTokenCountInMenuBar = UserDefaults.standard.bool(forKey: "showsTokenCountInMenuBar")
+        if let savedDisplayMode = UserDefaults.standard.string(forKey: "menuBarDisplayMode"),
+           let displayMode = MenuBarDisplayMode(rawValue: savedDisplayMode) {
+            self.menuBarDisplayMode = displayMode
+        } else if UserDefaults.standard.object(forKey: "showsTokenCountInMenuBar") != nil,
+                  UserDefaults.standard.bool(forKey: "showsTokenCountInMenuBar") {
+            self.menuBarDisplayMode = .tokens
+        }
         
         // Try to load cached values immediately for instant display
         loadCachedValues()
@@ -132,9 +138,9 @@ class UsageManager: ObservableObject {
         }
     }
 
-    func setShowsTokenCountInMenuBar(_ showsTokenCount: Bool) {
-        showsTokenCountInMenuBar = showsTokenCount
-        UserDefaults.standard.set(showsTokenCount, forKey: "showsTokenCountInMenuBar")
+    func setMenuBarDisplayMode(_ displayMode: MenuBarDisplayMode) {
+        menuBarDisplayMode = displayMode
+        UserDefaults.standard.set(displayMode.rawValue, forKey: "menuBarDisplayMode")
     }
 
     var todayTotalTokens: Int {


### PR DESCRIPTION
Adding new option to the menu to be able to change what is being displayed in the menu bar
<img width="326" height="393" alt="Screenshot 2026-07-16 at 6 09 36 PM" src="https://github.com/user-attachments/assets/67ed0bb4-7629-41c2-a11e-2fb39e27f771" />

Tokens
<img width="51" height="33" alt="Screenshot 2026-07-16 at 6 09 49 PM" src="https://github.com/user-attachments/assets/f864a05f-953c-49d2-812f-90c3ec1d7620" />

Cost
<img width="56" height="33" alt="Screenshot 2026-07-16 at 6 09 55 PM" src="https://github.com/user-attachments/assets/2a2cf57f-4df6-429a-9de3-3df5319f79e7" />

Both
<img width="100" height="33" alt="Screenshot 2026-07-16 at 6 09 42 PM" src="https://github.com/user-attachments/assets/8b59b391-d680-4fbb-addc-88da379eb6cd" />

Also adjusted the size of the display for currencies since mine was cut of as "U..." where as now it reads "USD"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * メニューバーの表示内容を「コスト」「トークン数」「両方」から選択できるようになりました。
  * 選択した表示設定は保存され、次回起動時にも引き継がれます。
  * トークン数は見やすいK/M形式で表示されます。
  * 当日の入力・出力トークン合計を表示できるようになりました。

* **改善**
  * 通貨選択メニューの表示幅を調整し、項目を見やすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->